### PR TITLE
Increase ORA2 'Comments' and 'Feedback' field character limits

### DIFF
--- a/openassessment/templates/openassessmentblock/oa_rubric.html
+++ b/openassessment/templates/openassessmentblock/oa_rubric.html
@@ -44,7 +44,7 @@
                                 class="answer__value"
                                 value="{{ criterion.name }}"
                                 name="{{ criterion.name }}"
-                                maxlength="300"
+                                maxlength="25000"
                                 {% if criterion.feedback == 'required' %}required{% endif %}
                                 >
                             </textarea>
@@ -64,7 +64,7 @@
                 <textarea
                     id="assessment__rubric__question--feedback__value"
                     placeholder="{{ rubric_feedback_default_text }}"
-                    maxlength="500"
+                    maxlength="25000"
                 >
                 </textarea>
             </div>


### PR DESCRIPTION
The "Comments" textarea rendered after a submission previously had a 300 characters. The "Feedback" text box  allows for up to 500 characters. Some instructors prefer to use these boxes as ways of garnering extra input from a participant about another peer's submission and intend for participants to leave long, thoughtful responses in here. This commit increases the "Comments" and "Feedback" textarea limits to 100000 characters.